### PR TITLE
New: Die JSON Dateien dürfen auch im Verzeichnis `~/.config/letsencrypt` liegen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Die Skripte wurden unter Linux getestet und
 ## Konfiguration
 
 Die Skripte werden mittels 3 JSON Dateien konfiguriert, die manuell zu erstellen sind.
-Die Konfigurationsdateien müssen im gleichen Verzeichnis wie die Python Skripte liegen.
+Die Konfigurationsdateien müssen entweder im gleichen Verzeichnis wie die Python Skripte oder im Verzeichnis `~/.config/letsencrypt` liegen.
 
 In der Datei __einstellungen.json__ wird die im Zertifikat zu hinterlegende Emailadresse gepflegt.
 Weiterhin wird konfiguriert, ob die 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Die Skripte wurden unter Linux getestet und
 ## Konfiguration
 
 Die Skripte werden mittels 3 JSON Dateien konfiguriert, die manuell zu erstellen sind.
-Die Konfigurationsdateien müssen entweder im gleichen Verzeichnis wie die Python Skripte oder im Verzeichnis `~/.config/letsencrypt` liegen.
+Die Konfigurationsdateien müssen entweder im gleichen Verzeichnis wie die Python Skripte oder im Verzeichnis `~/.config/hosteurope-letsencrypt` liegen.
 
 In der Datei __einstellungen.json__ wird die im Zertifikat zu hinterlegende Emailadresse gepflegt.
 Weiterhin wird konfiguriert, ob die 

--- a/neu.py
+++ b/neu.py
@@ -1,10 +1,10 @@
 import json
 import os
 
-from shared import domain_list
+from shared import domain_list, configFile
 
 # Einstellungen einlesen
-with open('einstellungen.json') as config_file:
+with open(configFile('einstellungen.json')) as config_file:
     config = json.load(config_file)
 email = config['email']
 staging = config['staging']

--- a/neu.py
+++ b/neu.py
@@ -1,10 +1,10 @@
 import json
 import os
 
-from shared import domain_list, configFile
+from shared import domain_list, config_file
 
 # Einstellungen einlesen
-with open(configFile('einstellungen.json')) as config_file:
+with open(config_file('einstellungen.json')) as config_file:
     config = json.load(config_file)
 email = config['email']
 staging = config['staging']

--- a/shared.py
+++ b/shared.py
@@ -1,7 +1,12 @@
 import json
+import os
+
+def configFile(name) :
+    f = os.path.expanduser('~/.config/letsencrypt/' + name)
+    return os.path.abspath(name if os.path.isfile(name) or not os.path.isfile(f) else f)
 
 # Domain Mapping einlesen
-with open('domains.json') as domain_file:
+with open(configFile('domains.json')) as domain_file:
     domain_map = json.load(domain_file)
 
 # Domains auflisten wie von certbot erwartet

--- a/shared.py
+++ b/shared.py
@@ -1,12 +1,12 @@
 import json
 import os
 
-def configFile(name) :
-    f = os.path.expanduser('~/.config/letsencrypt/' + name)
+def config_file(name):
+    f = os.path.expanduser('~/.config/hosteurope-letsencrypt/' + name)
     return os.path.abspath(name if os.path.isfile(name) or not os.path.isfile(f) else f)
 
 # Domain Mapping einlesen
-with open(configFile('domains.json')) as domain_file:
+with open(config_file('domains.json')) as domain_file:
     domain_map = json.load(domain_file)
 
 # Domains auflisten wie von certbot erwartet

--- a/validate.py
+++ b/validate.py
@@ -4,13 +4,13 @@ import logging
 import os
 import uuid
 
-from shared import configFile
+from shared import config_file
 
 # manuelles Logging, da certbot Ausgabe dieses Skripts unterdrückt
 logging.basicConfig(filename='validation.log', level=logging.DEBUG, format='%(asctime)s %(message)s')
 
 # Mapping zwischen Domains und Verzeichnis auf FTP laden
-with open(configFile('domains.json')) as domain_file:
+with open(config_file('domains.json')) as domain_file:
     DOMAINS = json.load(domain_file)
 
 # zu validierende Domain, Dateinamen and Token Inhalt werden von certbot per Umgebungsvariable übergeben
@@ -28,7 +28,7 @@ if not path:
     exit(1)
 
 # FTP Zugangsdaten laden
-with open(configFile('ftp.json')) as ftp_file:
+with open(config_file('ftp.json')) as ftp_file:
     ftp_cfg = json.load(ftp_file)
 
 # mit FTP verbinden

--- a/validate.py
+++ b/validate.py
@@ -4,11 +4,13 @@ import logging
 import os
 import uuid
 
+from shared import configFile
+
 # manuelles Logging, da certbot Ausgabe dieses Skripts unterdrückt
 logging.basicConfig(filename='validation.log', level=logging.DEBUG, format='%(asctime)s %(message)s')
 
 # Mapping zwischen Domains und Verzeichnis auf FTP laden
-with open('domains.json') as domain_file:
+with open(configFile('domains.json')) as domain_file:
     DOMAINS = json.load(domain_file)
 
 # zu validierende Domain, Dateinamen and Token Inhalt werden von certbot per Umgebungsvariable übergeben
@@ -26,7 +28,7 @@ if not path:
     exit(1)
 
 # FTP Zugangsdaten laden
-with open('ftp.json') as ftp_file:
+with open(configFile('ftp.json')) as ftp_file:
     ftp_cfg = json.load(ftp_file)
 
 # mit FTP verbinden

--- a/verlaengern.py
+++ b/verlaengern.py
@@ -1,9 +1,9 @@
 import json
 import os
 
-from shared import domain_list, configFile
+from shared import domain_list, config_file
 
-with open(configFile('einstellungen.json')) as config_file:
+with open(config_file('einstellungen.json')) as config_file:
     config = json.load(config_file)
 staging = config['staging']
 

--- a/verlaengern.py
+++ b/verlaengern.py
@@ -1,9 +1,9 @@
 import json
 import os
 
-from shared import domain_list
+from shared import domain_list, configFile
 
-with open('einstellungen.json') as config_file:
+with open(configFile('einstellungen.json')) as config_file:
     config = json.load(config_file)
 staging = config['staging']
 


### PR DESCRIPTION
Die JSON Dateien `einstellungen.json`, `domains.json` und `ftp.json` werden zur Konfiguration benutzen. Wird eine dieser Dateien nicht im Verzeichnis der Skripte gefunden wird es alternativ im Verzeichnis `~/.config/letsencrypt` gesucht.

(Benutzer-spezifische) Konfigurationen in einem Unterverzeichnis `~/.config` abzulegen ist eine bewährte Praxis (insbesondere unter Unix) [1]. Konfigurationen können so leichter von Anwendungen getrennt betrachtet werden, was beispielsweise beim Erstellen von Backups oder Re-Installieren von Anwendungen sinnvoll ist. 


[1]: [Location of ini/config files in linux/unix?](https://stackoverflow.com/questions/1024114/location-of-ini-config-files-in-linux-unix)