### PR TITLE
Laufähigkeit als nicht-root, Support für DNS Challenge und Vorgehen für Bloghosting Pakete

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ die gewünschten Domains zu erstellen oder zu verlängern
 Das abschließende Einbinden des Zertifikats bleibt ein manueller Schritt, da Hosteurope dafür keine API
 bietet, die eine Automatisierung ermöglicht.
 
+Dieses Vorgehen wurde auch mit dem gegenüber den WebHosting Paketen eingeschränkten __Bloghosting (Wordpress)__ erfolgreich durchgeführt.
+
 
 ## Anforderungen
  
@@ -21,8 +23,8 @@ Für die Nutzung der Skripte wird benötigt:
 - Python 3
 - [certbot](https://certbot.eff.org/)
 
-Die Skripte wurden unter Linux getestet und 
-[das Vorgehen auf meinem Blog beschrieben](https://sebstein.hpfsc.de/2017/09/17/lets-encrypt-mit-hosteurope-webhosting-nutzen/).
+Die Skripte wurden unter Linux sowie dem Windows Subsystem for Linux getestet und 
+[das Vorgehen auf diesem Blog beschrieben](https://sebstein.hpfsc.de/2017/09/17/lets-encrypt-mit-hosteurope-webhosting-nutzen/).
 
 
 ## Konfiguration
@@ -78,7 +80,7 @@ Webserver im Unterverzeichnis _.well-known/acme-challenge_.
 
 __Achtung__: Wenn Du __Hosteurope Bloghosting (Wordpress)__ verwendest, ist zusätzliche Konfiguration nötig, damit die Domainvalidierung von __Let's Encrypt__ funktioniert.
 
-### Setup für _Hosteurope Bloghosting_
+### Konfiguration für _Hosteurope Bloghosting_
 
 Um die [Domain zu validieren](https://letsencrypt.org/docs/challenge-types/) fragt __Let's Encrypt__, falls die HTTP-01 Challenge verwendet wird, eine URL ab: `http://<YOUR_DOMAIN>/.well-known/acme-challenge/<TOKEN>`.
 Die Hosteurope Bloghosting Pakete kontrollieren die Dateien in `/`; als Kunde kann man per FTP lediglich Dateien im _Wordpress -Verzeichnis_ `cust_upload/` ablegen.
@@ -86,7 +88,7 @@ Die Hosteurope Bloghosting Pakete kontrollieren die Dateien in `/`; als Kunde ka
 Wir müssen also sicherstellen, dass die Validierung über `/.well-known/acme-challenge/<TOKEN>` funktioniert, in dem die von diesen Skripten (`validate.py` automatisiert den Tokenupload über FTP) erzeugte Datei geladen wird.
 
 
-Installiere das Wordpress Plugin [__Redirection__](https://redirection.me/)_
+Installiere das Wordpress Plugin [__Redirection__](https://redirection.me/)
 
 In den Optionen des Plugins setze __IP-Protokollierung__ auf `keine` oder `Anonymisiert` #DSGVO
 
@@ -108,7 +110,7 @@ Lege nun eine _Umleitung_ an mit folgenden Parametern:
 In der oben genannten Ziel-URL ist der Pfadanteil `www/` enthalten. Dieses Verzeichnis musst Du selbst (z.B. per FTP) innerhalb von `cust_upload/` anlegen. Ausserdem muss dieser Pfad als Mapping in __domains.json__ angegeben werden, damit der Upload des Tokens die Datei wie von _Let's Encrypt_ erwartet erzeugen kann.
 
 
-## Nutzung
+## Nutzung der Skripte
 
 Ein neues Zertifikat wird erstellt mittels:
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Ein bestehendes Zertifikat wird verlängert mittels:
 
     sudo python3 verlaengern.py
     
-Wenn die Skripte mit Root-Rechten laufen, wird _certbot_ die generierten Zertifikate unter _/etc/letsencrypt_
-ablegen. Wird _certbot_ als user aufgerufen, werden die _certbot_ Parameter `--work-dir, --config-dir, --logs-dir` gesetzt und _~/.config/hosteurope-letsencrypt_ als Basis verwendet.
+Wenn die Skripte mit Root-Rechten laufen, legt _certbot_ die generierten Zertifikate unter _/etc/letsencrypt_
+ab. Wird _certbot_ als user aufgerufen, werden die _certbot_ Parameter `--work-dir, --config-dir, --logs-dir` gesetzt und _~/.config/hosteurope-letsencrypt_ als Basis verwendet.
 
 Die folgenden Abschnitte erklären im Detail, was bei jedem Skript genau geschieht.   
 
@@ -179,9 +179,5 @@ hochgeladen werden:
 
 Das Passwort Feld muss leer bleiben!
 
-Nach dem Hochladen startet Hosteurope den Webserver neu und das Zertifikat ist innerhalb weniger Minuten
-online.
-
-
-
+Nach dem Hochladen startet Hosteurope den Webserver neu und das Zertifikat ist innerhalb weniger Minuten online.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ In den Optionen des Plugins setze __IP-Protokollierung__ auf `keine` oder `Anony
 Damit das Redirection Plugin funktioniert, muss eine Wordpress `.htaccess` vorhanden sein. Diese kannst du automatisch erzeugen lassen, indem Du _Einstellungen > Permalinks_ öffnest und speicherst.
 
 Lege nun eine _Umleitung_ an mit folgenden Parametern:
+
 | Parameter            | Wert                                                                 |
 |----------------------|----------------------------------------------------------------------|
 | URL-Quelle           | `^/\.well-known/acme-challenge/(.*)`                                 |
@@ -101,6 +102,8 @@ Lege nun eine _Umleitung_ an mit folgenden Parametern:
 | Wenn übereinstimmend | `Umleitung zur URL`                                                  |
 | HTTP-Status Code     | `301 Dauerhaft verschoben`                                           |
 | Ziel-URL             | `http://<YOUR_DOMAIN>/cust_upload/www/.well-known/acme-challenge/$1` |
+
+
 
 In der oben genannten Ziel-URL ist der Pfadanteil `www/` enthalten. Dieses Verzeichnis musst Du selbst (z.B. per FTP) innerhalb von `cust_upload/` anlegen. Ausserdem muss dieser Pfad als Mapping in __domains.json__ angegeben werden, damit der Upload des Tokens die Datei wie von _Let's Encrypt_ erwartet erzeugen kann.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zum Beispiel noch mit den richtigen Parametern experimentiert.
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | email |  E-Mail Adresse für den Let's Encrypt Account. |
 | staging | `true` aktiviert die Verwendung der Let's Encrypt Staging Umgebung. |
-| preferred-challenge |  Standard: http. Dies setzt die zu verwendende [Let's Encrypt Challenge](https://letsencrypt.org/docs/challenge-types/ ) auf HTTP oder DNS. |
+| preferred-challenge |  `http` oder `dns`. Setzt die zu verwendende [Let's Encrypt Challenge](https://letsencrypt.org/docs/challenge-types/ ) auf HTTP oder DNS. |
 
 
 In der Datei __domains.json__ gibt man die Domains an, für die ein Zertifikat erstellt werden soll.
@@ -78,7 +78,7 @@ Webserver im Unterverzeichnis _.well-known/acme-challenge_.
 
 __Achtung__: Wenn Du __Hosteurope Bloghosting (Wordpress)__ verwendest, ist zusätzliche Konfiguration nötig, damit die Domainvalidierung von __Let's Encrypt__ funktioniert.
 
-### Setup für Hosteurope _Bloghosting_
+### Setup für _Hosteurope Bloghosting_
 
 Um die [Domain zu validieren](https://letsencrypt.org/docs/challenge-types/) fragt __Let's Encrypt__, falls die HTTP-01 Challenge verwendet wird, eine URL ab: `http://<YOUR_DOMAIN>/.well-known/acme-challenge/<TOKEN>`.
 Die Hosteurope Bloghosting Pakete kontrollieren die Dateien in `/`; als Kunde kann man per FTP lediglich Dateien im _Wordpress -Verzeichnis_ `cust_upload/` ablegen.
@@ -86,19 +86,24 @@ Die Hosteurope Bloghosting Pakete kontrollieren die Dateien in `/`; als Kunde ka
 Wir müssen also sicherstellen, dass die Validierung über `/.well-known/acme-challenge/<TOKEN>` funktioniert, in dem die von diesen Skripten (`validate.py` automatisiert den Tokenupload über FTP) erzeugte Datei geladen wird.
 
 
-1. Installiere das Wordpress Plugin [__Redirection__](https://redirection.me/)_
-2. In den Optionen des Plugins setze __IP-Protokollierung__ auf `keine` oder `Anonymisiert` #DSGVO
-3. Lege eine _Umleitung_ an mit folgenden Parametern:
-```
-URL-Quelle: `^/\.well-known/acme-challenge/(.*)`
-Titel: `Let's Encrypt Domain Validation`
-Passend: `Nur URL`
-Wenn übereinstimmend `Umleitung zur URL` mit HTTP-Status `301 Dauerhaft verschoben`
-Ziel-URL: `http://<YOUR_DOMAIN>/cust_upload/www/.well-known/acme-challenge/$1`
-```
+Installiere das Wordpress Plugin [__Redirection__](https://redirection.me/)_
 
-> Damit das Redirection Plugin funktioniert, muss eine Wordpress `.htaccess` vorhanden sein. Diese kannst du automatisch erzeugen lassen, indem Du _Einstellungen > Permalinks_ öffnest und speicherst.
+In den Optionen des Plugins setze __IP-Protokollierung__ auf `keine` oder `Anonymisiert` #DSGVO
 
+Damit das Redirection Plugin funktioniert, muss eine Wordpress `.htaccess` vorhanden sein. Diese kannst du automatisch erzeugen lassen, indem Du _Einstellungen > Permalinks_ öffnest und speicherst.
+
+Lege eine _Umleitung_ an mit folgenden Parametern:
+| Parameter | Wert |
+|-----------|------|
+| URL-Quelle |  `^/\.well-known/acme-challenge/(.*)` |
+| Titel | `Let's Encrypt Domain Validation` |
+| Passend | `Nur URL` |
+| Wenn übereinstimmend | `Umleitung zur URL` |
+| HTTP-Status Code | `301 Dauerhaft verschoben` |
+| Ziel-URL | `http://<YOUR_DOMAIN>/cust_upload/www/.well-known/acme-challenge/$1` |
+
+
+In der oben genannten Ziel-URL ist der Pfadanteil `www/` enthalten. Dieses Verzeichnis musst Du selbst (z.B. per FTP) innerhalb von `cust_upload/` anlegen. Ausserdem muss dieser Pfad als Mapping in __domains.json__ angegeben werden, damit der Upload des Tokens die Datei wie von _Let's Encrypt_ erwartet erzeugen kann.
 
 
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ Lege nun eine _Umleitung_ an mit folgenden Parametern:
 In der oben genannten Ziel-URL ist der Pfadanteil `www/` enthalten. Dieses Verzeichnis musst Du selbst (z.B. per FTP) innerhalb von `cust_upload/` anlegen. Ausserdem muss dieser Pfad als Mapping in __domains.json__ angegeben werden, damit der Upload des Tokens die Datei wie von _Let's Encrypt_ erwartet erzeugen kann.
 
 
-
 ## Nutzung
 
 Ein neues Zertifikat wird erstellt mittels:

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ In den Optionen des Plugins setze __IP-Protokollierung__ auf `keine` oder `Anony
 Damit das Redirection Plugin funktioniert, muss eine Wordpress `.htaccess` vorhanden sein. Diese kannst du automatisch erzeugen lassen, indem Du _Einstellungen > Permalinks_ öffnest und speicherst.
 
 Lege nun eine _Umleitung_ an mit folgenden Parametern:
-| Parameter | Wert |
+| Parameter            | Wert                                                                 |
 |----------------------|----------------------------------------------------------------------|
-| URL-Quelle | `^/\.well-known/acme-challenge/(.*)` |
-| Titel | `true` aktiviert die Verwendung der Let's Encrypt Staging Umgebung. |
-| Passend | `Nur URL` |
-| Wenn übereinstimmend | `Umleitung zur URL` |
-| HTTP-Status Code | `301 Dauerhaft verschoben` |
-| Ziel-URL | `http://<YOUR_DOMAIN>/cust_upload/www/.well-known/acme-challenge/$1` |
+| URL-Quelle           | `^/\.well-known/acme-challenge/(.*)`                                 |
+| Titel                | `true` aktiviert die Verwendung der Let's Encrypt Staging Umgebung.  |
+| Passend              | `Nur URL`                                                            |
+| Wenn übereinstimmend | `Umleitung zur URL`                                                  |
+| HTTP-Status Code     | `301 Dauerhaft verschoben`                                           |
+| Ziel-URL             | `http://<YOUR_DOMAIN>/cust_upload/www/.well-known/acme-challenge/$1` |
 
 In der oben genannten Ziel-URL ist der Pfadanteil `www/` enthalten. Dieses Verzeichnis musst Du selbst (z.B. per FTP) innerhalb von `cust_upload/` anlegen. Ausserdem muss dieser Pfad als Mapping in __domains.json__ angegeben werden, damit der Upload des Tokens die Datei wie von _Let's Encrypt_ erwartet erzeugen kann.
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,16 @@ zum Beispiel noch mit den richtigen Parametern experimentiert.
 
     {
       "email": "webmaster@example.com",
-      "staging": false
+      "staging": false,
+      "preferred-challenge": "http"
     }
+
+| Parameter | Bedeutung |
+|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| email |  E-Mail Adresse für den Let's Encrypt Account. |
+| staging | `true` aktiviert die Verwendung der Let's Encrypt Staging Umgebung. |
+| preferred-challenge |  Standard: http. Dies setzt die zu verwendende [Let's Encrypt Challenge](https://letsencrypt.org/docs/challenge-types/ ) auf HTTP oder DNS. |
+
 
 In der Datei __domains.json__ gibt man die Domains an, für die ein Zertifikat erstellt werden soll.
 Neben den Domainamen muss weiterhin der Pfad auf dem FTP Server angegeben werden, damit die Skripte

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zum Beispiel noch mit den richtigen Parametern experimentiert.
 |---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | email |  E-Mail Adresse für den Let's Encrypt Account. |
 | staging | `true` aktiviert die Verwendung der Let's Encrypt Staging Umgebung. |
-| preferred-challenge |  Standard: http. Dies setzt die zu verwendende [Let's Encrypt Challenge](https://letsencrypt.org/docs/challenge-types/ ) auf HTTP oder DNS. |
+| preferred-challenge |  `http` oder `dns`. Setzt die zu verwendende [Let's Encrypt Challenge](https://letsencrypt.org/docs/challenge-types/ ) auf HTTP oder DNS. |
 
 
 In der Datei __domains.json__ gibt man die Domains an, für die ein Zertifikat erstellt werden soll.
@@ -78,7 +78,7 @@ Webserver im Unterverzeichnis _.well-known/acme-challenge_.
 
 __Achtung__: Wenn Du __Hosteurope Bloghosting (Wordpress)__ verwendest, ist zusätzliche Konfiguration nötig, damit die Domainvalidierung von __Let's Encrypt__ funktioniert.
 
-### Setup für Hosteurope _Bloghosting_
+### Setup für _Hosteurope Bloghosting_
 
 Um die [Domain zu validieren](https://letsencrypt.org/docs/challenge-types/) fragt __Let's Encrypt__, falls die HTTP-01 Challenge verwendet wird, eine URL ab: `http://<YOUR_DOMAIN>/.well-known/acme-challenge/<TOKEN>`.
 Die Hosteurope Bloghosting Pakete kontrollieren die Dateien in `/`; als Kunde kann man per FTP lediglich Dateien im _Wordpress -Verzeichnis_ `cust_upload/` ablegen.
@@ -86,19 +86,23 @@ Die Hosteurope Bloghosting Pakete kontrollieren die Dateien in `/`; als Kunde ka
 Wir müssen also sicherstellen, dass die Validierung über `/.well-known/acme-challenge/<TOKEN>` funktioniert, in dem die von diesen Skripten (`validate.py` automatisiert den Tokenupload über FTP) erzeugte Datei geladen wird.
 
 
-1. Installiere das Wordpress Plugin [__Redirection__](https://redirection.me/)_
-2. In den Optionen des Plugins setze __IP-Protokollierung__ auf `keine` oder `Anonymisiert` #DSGVO
-3. Lege eine _Umleitung_ an mit folgenden Parametern:
-```
-URL-Quelle: `^/\.well-known/acme-challenge/(.*)`
-Titel: `Let's Encrypt Domain Validation`
-Passend: `Nur URL`
-Wenn übereinstimmend `Umleitung zur URL` mit HTTP-Status `301 Dauerhaft verschoben`
-Ziel-URL: `http://<YOUR_DOMAIN>/cust_upload/www/.well-known/acme-challenge/$1`
-```
+Installiere das Wordpress Plugin [__Redirection__](https://redirection.me/)
 
-> Damit das Redirection Plugin funktioniert, muss eine Wordpress `.htaccess` vorhanden sein. Diese kannst du automatisch erzeugen lassen, indem Du _Einstellungen > Permalinks_ öffnest und speicherst.
+In den Optionen des Plugins setze __IP-Protokollierung__ auf `keine` oder `Anonymisiert` #DSGVO
 
+Damit das Redirection Plugin funktioniert, muss eine von Wordpress verwaltete `.htaccess` vorhanden sein. Diese kannst du automatisch erzeugen lassen, indem Du _Einstellungen > Permalinks_ öffnest und speicherst.
+
+Lege nun eine _Umleitung_ an mit folgenden Parametern:
+| Parameter | Wert |
+|----------------------|----------------------------------------------------------------------|
+| URL-Quelle | `^/\.well-known/acme-challenge/(.*)` |
+| Titel | `true` aktiviert die Verwendung der Let's Encrypt Staging Umgebung. |
+| Passend | `Nur URL` |
+| Wenn übereinstimmend | `Umleitung zur URL` |
+| HTTP-Status Code | `301 Dauerhaft verschoben` |
+| Ziel-URL | `http://<YOUR_DOMAIN>/cust_upload/www/.well-known/acme-challenge/$1` |
+
+In der oben genannten Ziel-URL ist der Pfadanteil `www/` enthalten. Dieses Verzeichnis musst Du selbst (z.B. per FTP) innerhalb von `cust_upload/` anlegen. Ausserdem muss dieser Pfad als Mapping in __domains.json__ angegeben werden, damit der Upload des Tokens die Datei wie von _Let's Encrypt_ erwartet erzeugen kann.
 
 
 

--- a/neu.py
+++ b/neu.py
@@ -5,17 +5,46 @@ import os
 
 from shared import domain_list, config_file
 
+
+# certbot tries to write to /var/log/letsencrypt by default; because of this, running as root is required.
+# certbot Error Message:
+# Either run as root, or set --config-dir, --work-dir, and --logs-dir to writeable paths.
+is_root = os.geteuid() == 0
+home_dir = os.path.expanduser("~/.config/hosteurope-letsencrypt")
+certbot_config_dir = home_dir
+certbot_work_dir = home_dir
+certbot_logs_dir = os.path.expanduser("~/.config/hosteurope-letsencrypt/logs")
+if not is_root and not os.path.exists(certbot_logs_dir):
+    os.makedirs(certbot_logs_dir)
+
+
 # Einstellungen einlesen
 with open(config_file('einstellungen.json')) as cfg_file:
     config = json.load(cfg_file)
 email = config['email']
 staging = config['staging']
 
+challenge = "http"
+if "preferred-challenge" in config:
+    challenge = config["preferred-challenge"]
+
+
 # certbot Kommando zusammenbauen
-cmd = 'certbot certonly --manual --manual-auth-hook "python3 validate.py" --agree-tos --manual-public-ip-logging-ok'
+cmd = 'certbot certonly --manual --agree-tos --manual-public-ip-logging-ok'
 cmd += ' -m ' + email
+cmd += ' --preferred-challenge=' + challenge
+if "http" == challenge:
+    cmd += ' --manual-auth-hook "python3 validate.py"'
 if staging:
     cmd += ' --staging'
+
+
+if not is_root:
+    cmd += ' --logs-dir ' + certbot_logs_dir
+    cmd += ' --work-dir ' + certbot_work_dir
+    cmd += ' --config-dir ' + certbot_config_dir
+
+
 cmd += domain_list
 
 # Sicherheitsabfrage

--- a/validate.py
+++ b/validate.py
@@ -16,12 +16,30 @@ with open(config_file('domains.json')) as domain_file:
 
 # zu validierende Domain, Dateinamen and Token Inhalt werden von certbot per Umgebungsvariable übergeben
 domain = os.environ['CERTBOT_DOMAIN']
-filename = os.environ['CERTBOT_TOKEN']
+filename = None
+if 'CERTBOT_TOKEN' in os.environ:
+    filename = os.environ['CERTBOT_TOKEN']
 content = os.environ['CERTBOT_VALIDATION']
 
+logging.debug('Challenge: ' + ("http" if filename != None else "dns"))
 logging.debug('Domain: ' + domain)
-logging.debug('Dateiname: ' + filename)
 logging.debug('Inhalt: ' + content)
+if filename != None:
+    logging.debug('Dateiname: ' + filename)
+
+
+if filename == None or len(filename) == 0:
+    # Filename is only available if the HTTP challenge is used. For the DNS challenge it's not available.
+    print("validate: Assuming challenge = DNS\n")
+    print("validate: Create the following DNS entry\n")
+    print("""_acme-challenge.%s. 300 IN TXT "%s" """ % (domain, content), flush=True)
+    print('Confirm with "j" to proceed with DNS validation! (j/n): ', flush=True)
+
+    proceed = input('Confirm with "j" to proceed with DNS validation! (j/n): ')
+    if proceed != 'j':
+        print("Aborting.")
+        exit(1)
+    exit(0)
 
 path = DOMAINS.get(domain)
 if not path:

--- a/validate.py
+++ b/validate.py
@@ -16,30 +16,13 @@ with open(config_file('domains.json')) as domain_file:
 
 # zu validierende Domain, Dateinamen and Token Inhalt werden von certbot per Umgebungsvariable übergeben
 domain = os.environ['CERTBOT_DOMAIN']
-filename = None
-if 'CERTBOT_TOKEN' in os.environ:
-    filename = os.environ['CERTBOT_TOKEN']
+filename = os.environ['CERTBOT_TOKEN']
 content = os.environ['CERTBOT_VALIDATION']
 
-logging.debug('Challenge: ' + ("http" if filename != None else "dns"))
 logging.debug('Domain: ' + domain)
 logging.debug('Inhalt: ' + content)
-if filename != None:
-    logging.debug('Dateiname: ' + filename)
+logging.debug('Dateiname: ' + filename)
 
-
-if filename == None or len(filename) == 0:
-    # Filename is only available if the HTTP challenge is used. For the DNS challenge it's not available.
-    print("validate: Assuming challenge = DNS\n")
-    print("validate: Create the following DNS entry\n")
-    print("""_acme-challenge.%s. 300 IN TXT "%s" """ % (domain, content), flush=True)
-    print('Confirm with "j" to proceed with DNS validation! (j/n): ', flush=True)
-
-    proceed = input('Confirm with "j" to proceed with DNS validation! (j/n): ')
-    if proceed != 'j':
-        print("Aborting.")
-        exit(1)
-    exit(0)
 
 path = DOMAINS.get(domain)
 if not path:


### PR DESCRIPTION
- In `einstellungen.json` kann jetzt die preferred-challenge (http, dns) angegeben werden. `http` verwendet weiterhin den FTP Upload.
- `neu.py` kann auch von nicht-root Usern gestartet werden
- die README enthält die Beschreibung, wie man die Let's Encrypt Validierung für _Hosteurope Bloghosting (Wordpress) Pakete_ hinbekommt.