### PR TITLE
Fix: in verlaengern.py certbot claims to require the email-address

### DIFF
--- a/verlaengern.py
+++ b/verlaengern.py
@@ -20,12 +20,14 @@ if not is_root and not os.path.exists(certbot_logs_dir):
 # Einstellungen einlesen
 with open(config_file('einstellungen.json')) as cfg_file:
     config = json.load(cfg_file)
+email = config['email']
 staging = config['staging']
 
 challenge = config.get('preferred-challenge', 'http')
 
 # certbot Kommando zusammenbauen
 cmd = 'certbot certonly -n --manual --agree-tos --manual-public-ip-logging-ok'
+cmd += ' -m ' + email
 if 'http' == challenge:
     cmd += ' --manual-auth-hook "python3 validate.py"'
 if staging:


### PR DESCRIPTION
Moin,

beim Aufruf von verlaengern.py unter Ubuntu 20.04 bekam ich diese Meldung:
> You should register before running non-interactively, or provide --agree-tos and --email <email_address> flags.

Die Lösung war recht simpel: Ich habe die E-Mail-Adresse als Parameter übergeben. Die zwei Zeilen stehen im Pull Request. 

Andreas