### PR TITLE
Support Wildcard DNS Challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,27 @@ _/etc/letsencrypt_ oder als User unter _~/.config/hosteurope-letsencrypt_ ab.
 Die Zertifikatsdateien enthalten eine Nummer in ihrem Dateinamen, die bei jeder Verlängerung um 1 hochgezählt wird.
 Das neueste Zertifikat ist immer jenes, mit der höchsten Nummer im Dateinamen.
 
+### DNS Challenge eintragen (set_dns_challenge.py)
+
+`set_dns_challenge` benötigt das Python-Paket `pyppeteer`. 
+Das Paket kann man über `pip install pyppeteer` installieren.
+Alternativ kann auch pipenv verwendet werden: Dafür muss man `pipenv` auf dem System installieren.
+Danach kann mit `pipenv shell` und `pipenv install` die nötige Abhängigkeit hinzugefügt werden.
+
+Durch _certbot_ wird bei einer Validierung per DNS eine DNS Challenge erwartet. In der Regel wird dieses Verfahren für Wildcard Domains (*.domain.de) genutzt und setzt einen DNS TXT record vorraus in dem der Challenge-String angegeben werden muss. Der DNS-Eintrag muss vorher per Hand angelegt werden, unter `Domainservices > Domain-Administration > Namesserver- / DNS-Einträge ändern > mydomain.de`. Dort muss ein neuer TXT Eintrag mit `_acme-challenge.domain.de` angelegt werden. Das Skript `set_dns_challenge.py` erlaubt das automatisierte Eintragen des Challenge-String.
+Dazu wird das Skript mit der Domain und dem Challenge-String aus _certbot_ als Parametern gestartet. 
+
+    ./set_dns_challenge.py -d *.domain.de -c 3940jw09spfi3wq9rwjiefpw93r0w9
+
+Die Domains und dazu passenden URLs aus KIS, die das Skript benötigt, können in der domains.json eingetragen werden. (Auch parallel zu Eintragen zur http Validierung.) Die benötigte Seite der URL ist dieselbe wie zum Eintragen des TXT Records oben.
+
+    {
+        "*.example.com": "https://kis.hosteurope.de/administration/domainservices/index.php?menu=....&mode=autodns&submode=edit&domain=....",
+        "*.example.de": "https://kis.hosteurope.de/administration/domainservices/index.php?menu=....&mode=autodns&submode=edit&domain=...."
+    }
+
+Nach Ausführen den Skripts dauert es ca. 10-15 Sekunden bis der DNS-Eintrag aktualisiert verfügbar ist. Dann kann im _certbot_ Enter gedrückt werden, um die DNS-Challenge zu prüfen.
+ 
 ### Zertifikat einbinden (set_certificate.py)
 
 `set_certificate` benötigt das Python-Paket `pyppeteer`. 

--- a/neu.py
+++ b/neu.py
@@ -48,4 +48,16 @@ if answer != 'j':
     exit(0)
 
 # neues Zertifikat erstellen
-os.system(cmd)
+if not 'dns' == challenge:
+    os.system(cmd)
+else:
+    print('Folgenden Aufruf ausführen:')
+    print('')
+    print(f'    {cmd}')
+    print('')
+    print('Dann in einem separaten Terminal das Skript set_dns_challenge.py mit den Parametern aus dem obigen Aufruf starten!')
+    print('')
+    print(f'    ./set_dns_challenge.py --domain <*.domain.tld> --challenge <challenge-string>')
+    print('')
+    print('Ca. 15 Sekunden warten bis die DNS-Änderungen verfügbar sind und dann im ersten Terminal ENTER drücken.')
+

--- a/set_dns_challenge.py
+++ b/set_dns_challenge.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# coding=utf-8
+import json
+import asyncio
+from pyppeteer import launch
+from shared import domain_list, config_file
+import time
+import argparse
+
+
+# parse cmdline
+parser = argparse.ArgumentParser()
+parser.add_argument('-d', '--domain', dest='domain', required=True)
+parser.add_argument('-c', '--challenge', dest='challenge', required=True)
+args = parser.parse_args()
+
+# zu validierende Domain, Dateinamen and Token Inhalt werden von certbot per Umgebungsvariable übergeben
+domain = args.domain 
+content = args.challenge
+
+print('Domain:    ' + domain)
+print('Challenge: ' + content)
+
+# Mapping zwischen Domains und Verzeichnis auf FTP laden
+with open(config_file('domains.json')) as domain_file:
+   domains_file = json.load(domain_file)
+
+path = domains_file.get(domain)
+if not path:
+    print('Kein Mapping für Domain gefunden. Breche ab! ->' + domain)
+    exit(1)
+
+cfg_file = open(config_file('einstellungen.json'))
+config = json.load(cfg_file)
+
+
+async def set_challenge_for(browser, url, token, domain_name):
+    page = await browser.newPage()
+    # Open SSL page
+    print("-> Lade DNS Seite")
+    await page.goto(url, {'waitUntil': 'networkidle2'})
+    await page.setViewport({'width': 1366, 'height': 1000})
+    time.sleep(1)
+
+    # Fill in form and submit
+    print("-> Suche nach Zieleintrag und füge Challenge-String ein")
+    parentElement = await page.Jx(f'//td[text()[contains(., "_acme-challenge.{domain_name}")]]/..')
+    time.sleep(2)
+    if len(parentElement) <= 0:
+        print(f"-> !!! DNS TXT record _acme-challenge.{domain_name} nicht gefunden. Bitte auf KIS-DNS-Seite manuell hinzufügen!")
+        input('ENTER zum Beenden.')
+        exit(1)
+    textField = await parentElement[0].querySelector('input[name="pointer"]')
+    await textField.focus()
+    await textField.click({ 'clickCount': 3 })
+    await page.keyboard.type(token)
+    await page.keyboard.press("Enter")
+    time.sleep(1)
+    await page.waitForNavigation({'waitUntil': 'networkidle2'})
+
+    # Log result
+    print("-> Update Challenge fertig")
+    await page.screenshot({'path': domain_name+'-dns-validate.log.jpeg'})
+
+
+async def set_challenge():
+    # Login
+    print("Starte Browser...")
+    browser = await launch({'headless': False, 'slowMo': 1, 'devtools': False, 'executablePath': '/usr/bin/chromium-browser'})
+    time.sleep(2)
+    page = await browser.newPage()
+    print("Starte Login...")
+    await page.goto('https://kis.hosteurope.de', {'waitUntil': 'networkidle2'})
+    time.sleep(1)
+    await page.focus("input[autocomplete=email]")
+    await page.keyboard.type(config["kis-username"])
+    await page.focus("input[type=password]")
+    await page.keyboard.type(config["kis-password"])
+    await page.keyboard.press("Enter")
+    await page.waitForNavigation({'waitUntil': 'networkidle2'})
+    time.sleep(1)
+
+    #2FA
+    if (config["kis-2fa"]):
+        print("Starte 2FA")
+        await page.focus("input[id=1]")
+        await page.keyboard.type(input("Enter the 2FA you got via SMS here: "))
+        await page.keyboard.press("Enter")
+        await page.waitForNavigation({'waitUntil': 'networkidle2'})
+        time.sleep(1)
+
+    # process domains
+    for (domain_cfg, url) in domains_file.items():  # url as "https://kis.hosteurope.de/administration/domainservices/index.php?menu=<idx>&mode=autodns&submode=edit&domain=<domain.de>"
+        if (domain_cfg in domain):       
+            if domain_cfg.startswith("*."):
+                domain_name = domain_cfg[2:]
+            else:
+                domain_name = domain_cfg
+
+            print(f"Setze Challenge für: {domain_name}")
+            await set_challenge_for(browser, url, content, domain_name)
+            print(f"... ca. 15 Sekunden warten, bis die Änderungen verfügbar sind.")
+
+
+    print("Fertig.")
+    await browser.close()
+
+try:
+    asyncio.get_event_loop().run_until_complete(set_challenge())
+except Exception as err:
+    print(f"FEHLER: Unerwarteter {err=}, {type(err)=}")
+    exit(1)
+
+exit(0)

--- a/verlaengern.py
+++ b/verlaengern.py
@@ -26,10 +26,10 @@ staging = config['staging']
 challenge = config.get('preferred-challenge', 'http')
 
 # certbot Kommando zusammenbauen
-cmd = 'certbot certonly -n --manual --agree-tos --expand'
+cmd = 'certbot certonly --manual --agree-tos --expand'
 cmd += ' -m ' + email
 if 'http' == challenge:
-    cmd += ' --manual-auth-hook "python3 validate.py"'
+    cmd += ' --manual-auth-hook "python3 validate.py" -n'
 if staging:
     cmd += ' --staging'
 
@@ -48,4 +48,15 @@ if answer != 'j':
     exit(0)
 
 # neues Zertifikat erstellen
-os.system(cmd)
+if not 'dns' == challenge:
+    os.system(cmd)
+else:
+    print('Folgenden Aufruf ausführen:')
+    print('')
+    print(f'    {cmd}')
+    print('')
+    print('Dann in einem separaten Terminal das Skript set_dns_challenge.py mit den Parametern aus dem obigen Aufruf starten!')
+    print('')
+    print(f'    ./set_dns_challenge.py --domain <*.domain.tld> --challenge <challenge-string>')
+    print('')
+    print('Ca. 15 Sekunden warten bis die DNS-Änderungen verfügbar sind und dann im ersten Terminal ENTER drücken.')


### PR DESCRIPTION
Hi,

ich hab ein paar Ergänzungen und ein weiteres Skript eingeführt, um die Wildcard DNS Challenge zu ermöglichen. Leider funktioniert eine vollständige Automatisierung nicht, da die certbot hook scripte keine browser starten können und die Ausgaben auch nur nach Abschluss des Skripts ausgegeben werden...

IMHO solle vorher keine DNS Validation funktioniert haben, auch wenn sie konfigurierbar war. Von daher dürften die Änderungen nichts kaputt machen, sondern die DNS Challenge ermöglichen.

Ich hab es bisher nur mit Wildcard Certs getestet. Normale Zertifikate sollten aber auch möglich sein.

Bei Fragen und Problemen, lass es mich wissen...